### PR TITLE
feat: replace catppuccin theme with custom minimal status bar design

### DIFF
--- a/packages/tmux/default.nix
+++ b/packages/tmux/default.nix
@@ -2,13 +2,49 @@
 
 let
   mkTmux = pkgs.callPackage ./mkTmux.nix { };
+
+  sensible = pkgs.tmuxPlugins.mkTmuxPlugin rec {
+    pluginName = "sensible";
+    rtpFilePath = "sensible.tmux";
+    version = "25cb91f42d020f675bb0a2ce3fbd3a5d96119efa";
+    src = pkgs.fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-sensible";
+      rev = version;
+      sha256 = "sha256-sw9g1Yzmv2fdZFLJSGhx1tatQ+TtjDYNZI5uny0+5Hg=";
+    };
+  };
+
+  yank = pkgs.tmuxPlugins.mkTmuxPlugin rec {
+    pluginName = "yank";
+    rtpFilePath = "yank.tmux";
+    version = "acfd36e4fcba99f8310a7dfb432111c242fe7392";
+    src = pkgs.fetchFromGitHub {
+      owner = "tmux-plugins";
+      repo = "tmux-yank";
+      rev = version;
+      sha256 = "sha256-/5HPaoOx2U2d8lZZJo5dKmemu6hKgHJYq23hxkddXpA=";
+    };
+  };
+
+  smartsplits = pkgs.tmuxPlugins.mkTmuxPlugin rec {
+    pluginName = "smart-splits";
+    rtpFilePath = "smart-splits.tmux";
+    version = "v2.0.3";
+    src = pkgs.fetchFromGitHub {
+      owner = "mrjones2014";
+      repo = "smart-splits.nvim";
+      rev = version;
+      sha256 = "sha256-zfuBaSnudCWw0N1XAms9CeVrAuPEAPDXxLLg1rTX7FE=";
+    };
+  };
 in
 
 mkTmux {
   extraConfig = lib.readFile ./tmux.conf;
-  extraPlugins = with pkgs.tmuxPlugins; [
+  extraPlugins = [
     sensible
     yank
-    catppuccin
+    smartsplits
   ];
 }

--- a/packages/tmux/tmux.conf
+++ b/packages/tmux/tmux.conf
@@ -1,19 +1,15 @@
+#  Shell
 set-option -g default-command "/bin/bash"
 
-if-shell 'test "$(uname)" = "Darwin"' \
-  'set -g default-terminal "screen-256color"' \
-  'set -g default-terminal "tmux-256color"'
+# Terminal
+set -g default-terminal "tmux-256color"
+if-shell 'test "$(uname)" = "Darwin"' 'set -g default-terminal "screen-256color"'
+set-option -ga terminal-overrides ',xterm-256color:Tc'
 
-# Let there be color
-set-option -sa terminal-overrides ",xterm*:Tc"
-
-# Evil mode
+# Settings
 set -g mouse on
-
-# Why isnt this default
 set -s escape-time 0
 set -g status-interval 0
-
 set -g automatic-rename on
 set -g allow-rename off
 set -g automatic-rename-format ' #{b:pane_current_path}'
@@ -51,29 +47,29 @@ set -g repeat-time 500
 bind -r h previous-window
 bind -r l next-window
 
-bind-key -n C-h if -F "#{@pane-is-vim}" 'send-keys C-h' 'select-pane -L'
-bind-key -n C-j if -F "#{@pane-is-vim}" 'send-keys C-j' 'select-pane -D'
-bind-key -n C-k if -F "#{@pane-is-vim}" 'send-keys C-k' 'select-pane -U'
-bind-key -n C-l if -F "#{@pane-is-vim}" 'send-keys C-l' 'select-pane -R'
+# Popup style
+set -g popup-style "bg=terminal,fg=default"
+set -g popup-border-style "fg=cyan"
 
-bind-key -n M-h if -F "#{@pane-is-vim}" 'send-keys M-h' 'resize-pane -L 3'
-bind-key -n M-j if -F "#{@pane-is-vim}" 'send-keys M-j' 'resize-pane -D 3'
-bind-key -n M-k if -F "#{@pane-is-vim}" 'send-keys M-k' 'resize-pane -U 3'
-bind-key -n M-l if -F "#{@pane-is-vim}" 'send-keys M-l' 'resize-pane -R 3'
+# Message style
+set -g message-style "fg=yellow,bg=black"
+set -g message-command-style "fg=yellow,bg=black"
 
-bind-key -T copy-mode-vi 'C-h' select-pane -L
-bind-key -T copy-mode-vi 'C-j' select-pane -D
-bind-key -T copy-mode-vi 'C-k' select-pane -U
-bind-key -T copy-mode-vi 'C-l' select-pane -R
+# Pane style
+set -g pane-border-style 'fg=cyan'
+set -g pane-active-border-style "fg=cyan"
+set-window-option -g pane-border-status off
 
-# Plugins
-set -g @catppuccin_flavor "macchiato"
-set -g @catppuccin_window_status_style "rounded"
-set -g @catppuccin_window_default_text "#W"
-set -g @catppuccin_window_current_text "#W"
-set -g @catppuccin_window_text "#W"
-set -g status-right-length 100
+# Status style
+set -g status-style "fg=yellow,bg=black"
+set -g status-position top
+set -g status-justify absolute-centre
 set -g status-left-length 100
-set -g status-left ""
-set -g status-right "#{E:@catppuccin_status_application}"
-set -ag status-right "#{E:@catppuccin_status_session}"
+set -g status-left "#[fg=cyan,bg=black]#[fg=black,bg=cyan] #{session_windows}#[fg=cyan,bg=black]  "
+set -g status-right "#[fg=colour8,bg=black] #S #[fg=green,bg=black] #[fg=black,bg=green]󱫋 #{session_attached}#[fg=green,bg=black]"
+
+# Window style
+set -g window-status-style "fg=colour8,bg=black"
+set -g window-status-format "#[fg=default,bg=black]#[fg=default,bg=black]#W"
+set -g window-status-separator "  "
+set -g window-status-current-format "#[fg=cyan,bg=black]#[fg=cyan,bg=black]#W"


### PR DESCRIPTION
* add custom tmux plugin definitions for sensible, yank, and smart-splits
* replace catppuccin with custom cyan/yellow/black color scheme
* move status bar to top with centered window list
* simplify status sections to show session info and window count
* update terminal color settings and popup styling