### PR TITLE
docs: add Omarchy setup guide for MacBook Pro 14,3

### DIFF
--- a/docs/omarchy-setup.md
+++ b/docs/omarchy-setup.md
@@ -1,0 +1,47 @@
+# Omarchy setup
+
+## Hardware
+
+### MacBook Pro 14,3
+
+#### Power Management
+
+**Issue**: Sleep/Suspend functionality is not working properly  
+**Solution**: Configure the system to lock instead of suspend when the lid is closed, and use Hyprland to manage display state
+
+1. Configure systemd login manager:
+
+   Edit `/etc/systemd/logind.conf`:
+
+   ```conf
+   [Login]
+   HandleLidSwitch=lock
+   HandleLidSwitchExternalPower=lock
+   ```
+
+2. Configure Hyprland lid switch behavior:
+
+   Add to `.config/hypr/binding.conf`:
+
+   ```hyprlang
+   bindl = , switch:on:Lid Switch, exec, hyprctl keyword monitor "eDP-1,disable"
+   bindl = , switch:off:Lid Switch, exec, hyprctl keyword monitor "eDP-1,preferred,auto,2"
+   ```
+
+#### Input Devices
+
+**Issue**: TouchBar is not functional  
+**Solution**: Remap capslock to escape
+
+Add to `.config/hypr/input.conf`:
+
+```hyprlang
+input {
+  kb_options = caps:escape
+}
+```
+
+#### Audio
+
+**Issue**: Internal speakers are not working  
+**Workaround**: Use external speakers or headphones for audio output


### PR DESCRIPTION
* document power management configuration for lid switch handling
* add Hyprland display management for suspend/wake issues
* include TouchBar workaround with capslock remapping
* document audio limitations and external device workaround